### PR TITLE
Ensure that TEST_RESULT INSERT query has datetimes always in UTC

### DIFF
--- a/src/functions/postResult/framework/database/__tests__/query-builder.spec.ts
+++ b/src/functions/postResult/framework/database/__tests__/query-builder.spec.ts
@@ -7,9 +7,9 @@ describe('QueryBuilder', () => {
       const result = buildTestResultInsert(dummyTestResult, false);
       expect(result).toMatch(/INSERT INTO TEST_RESULT/);
     });
-    it('should have the correct date in the INSERT', () => {
+    it('should have the correct date as UTC in the INSERT', () => {
       const result = buildTestResultInsert(dummyTestResult, false);
-      expect(result).toMatch(/2019-06-05 12:38:00.000/);
+      expect(result).toMatch(/2019-06-05 11:38:00.000/);
     });
     it('should have the staff number in the INSERT', () => {
       const result = buildTestResultInsert(dummyTestResult, false);

--- a/src/functions/postResult/framework/database/query-builder.ts
+++ b/src/functions/postResult/framework/database/query-builder.ts
@@ -39,7 +39,8 @@ export const buildTestResultInsert = (test: StandardCarTestCATBSchema, isError: 
     isError ? ResultStatus.ERROR : ResultStatus.ACCEPTED,
   ];
 
-  return mysql.format(template, args);
+  // Specify that dates should be serialised in UTC.
+  return mysql.format(template, args, false, 'UTC');
 };
 
 export const buildUploadQueueInsert = (test: StandardCarTestCATBSchema, integration: IntegrationType): string => {


### PR DESCRIPTION
# Description and relevant Jira numbers
* #8 failed tests on the build server due to difference in the localtime used by default (BST locally, UTC on Jenkins).
* Specify to `mysql.format` that datetime should be put into the generated query in UTC.

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA