### PR TITLE
Fixes next upload batch query to lookup correct processing status

### DIFF
--- a/src/functions/getNextUploadBatch/framework/database/query-builder.ts
+++ b/src/functions/getNextUploadBatch/framework/database/query-builder.ts
@@ -12,7 +12,7 @@ export const buildTarsNextBatchQuery = (batchSize: number, interfaceType: string
   FROM TEST_RESULT JOIN UPLOAD_QUEUE
   WHERE TEST_RESULT.application_reference = UPLOAD_QUEUE.application_reference
   AND UPLOAD_QUEUE.interface = (SELECT id FROM INTERFACE_TYPE WHERE interface_type_name = ?)
-  AND UPLOAD_QUEUE.upload_status = (SELECT id FROM RESULT_STATUS WHERE result_status_name = 'PROCESSING')
+  AND UPLOAD_QUEUE.upload_status = (SELECT id FROM PROCESSING_STATUS WHERE processing_status_name = 'PROCESSING')
   ORDER BY UPLOAD_QUEUE.timestamp ASC
   LIMIT ?;
  `;


### PR DESCRIPTION
# Description and relevant Jira numbers

The existing query was looking up the processing status from the wrong table, calls to get the next upload batch were therefore coming back as empty even though there were test results waiting to be processed. This PR fixes this.

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA