### PR TITLE
MES-2858: Obtain authenticated staff number from request context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -280,11 +280,6 @@
       "integrity": "sha512-eE+xeiGBPgQsNcyg61JBqQS6NtxC+s2yfOikMCnc0Z4NqKujzmSahmtjLCKVQU/AyrTEQ76TOwQBnr8wGP2bmA==",
       "dev": true
     },
-    "@types/jwt-decode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
-      "integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
-    },
     "@types/mysql": {
       "version": "2.15.6",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.6.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@hapi/joi": "^15.0.3",
     "@types/hapi__joi": "^15.0.1",
-    "@types/jwt-decode": "^2.2.1",
     "enjoi": "^6.0.0",
     "moment": "^2.23.0",
     "mysql2": "^1.6.5"

--- a/src/common/application/utils/getEmployeeId.ts
+++ b/src/common/application/utils/getEmployeeId.ts
@@ -1,47 +1,10 @@
-import jwtDecode = require('jwt-decode');
 import * as logger from '../../../common/application/utils/logger';
+import { APIGatewayEventRequestContext } from 'aws-lambda';
 
-export const getEmployeeIdFromToken = (token: string): string | null => {
-  if (token === null || token === undefined) {
-    logger.warn('No authorisation token in request');
-    return null;
+export const getEmployeeIdFromRequestContext = (requestContext: APIGatewayEventRequestContext): string | null => {
+  if (requestContext.authorizer && typeof requestContext.authorizer.staffNumber === 'string') {
+    logger.error('No staff number found in request context');
+    return requestContext.authorizer.staffNumber;
   }
-
-  try {
-    const decodedToken: any = jwtDecode(token);
-    const employeeIdKey = process.env.EMPLOYEE_ID_EXT_KEY;
-    if (employeeIdKey.length === 0) {
-      logger.error('No key specified to find employee ID from JWT');
-      return null;
-    }
-
-    const employeeIdFromJwt = decodedToken[employeeIdKey];
-
-    if (!employeeIdFromJwt) {
-      logger.warn('No employeeId found in authorisation token');
-      return null;
-    }
-
-    return Array.isArray(employeeIdFromJwt) ?
-      getEmployeeIdFromArray(employeeIdFromJwt) : getEmployeeIdStringProperty(employeeIdFromJwt);
-  } catch (err) {
-    logger.error(err);
-    return null;
-  }
-};
-
-export const getEmployeeIdStringProperty = (employeeId: any): string | null => {
-  if (typeof employeeId !== 'string' || employeeId.trim().length === 0) {
-    logger.warn('No employeeId found in authorisation token');
-    return null;
-  }
-  return employeeId;
-};
-
-export const getEmployeeIdFromArray = (attributeArr: string[]): string | null => {
-  if (attributeArr.length === 0) {
-    logger.warn('No employeeId found in authorisation token');
-    return null;
-  }
-  return attributeArr[0];
+  return null;
 };

--- a/src/common/application/utils/getEmployeeId.ts
+++ b/src/common/application/utils/getEmployeeId.ts
@@ -3,8 +3,8 @@ import { APIGatewayEventRequestContext } from 'aws-lambda';
 
 export const getEmployeeIdFromRequestContext = (requestContext: APIGatewayEventRequestContext): string | null => {
   if (requestContext.authorizer && typeof requestContext.authorizer.staffNumber === 'string') {
-    logger.error('No staff number found in request context');
     return requestContext.authorizer.staffNumber;
   }
+  logger.error('No staff number found in request context');
   return null;
 };

--- a/src/functions/postResult/application/__tests__/jwt-verification-service.spec.ts
+++ b/src/functions/postResult/application/__tests__/jwt-verification-service.spec.ts
@@ -1,16 +1,8 @@
 import * as jwtVerificationSvc from '../jwt-verification-service';
-import { APIGatewayEvent } from 'aws-lambda';
+import { APIGatewayEvent, APIGatewayProxyEvent } from 'aws-lambda';
 import {
-  getEmployeeIdFromToken,
-  getEmployeeIdStringProperty,
-  getEmployeeIdFromArray,
-} from '../../../../common/application/utils/getEmployeeId';
-
-import {
-    sampleToken_12345678,
-    sampleTest_12345678,
-    sampleTest_87654321,
-    sampleTest_empty,
+  sampleToken_12345678,
+  sampleTest_12345678,
 } from '../../framework/__tests__/handler.spec.data';
 import { getStaffIdFromTest } from '../../framework/handler';
 const lambdaTestUtils = require('aws-lambda-test-utils');
@@ -20,75 +12,55 @@ describe('JWTVerificationService', () => {
   let dummyApigwEvent: APIGatewayEvent;
 
   beforeEach(() => {
-    process.env.EMPLOYEE_ID_EXT_KEY = 'extn.employeeId';
     dummyApigwEvent = lambdaTestUtils.mockEventCreator.createAPIGatewayEvent({
       headers: {
         Authorization: sampleToken_12345678,
       },
     });
+    // @ts-ignore
+    dummyApigwEvent.requestContext = {
+      authorizer: {
+        staffNumber: '12345678',
+      },
+    };
   });
 
   describe('verifyRequest', () => {
-    it('should return true if valid employeeId from JWT and staffId from body match', () => {
-      const res = jwtVerificationSvc.verifyRequest(dummyApigwEvent.headers, getStaffIdFromTest(sampleTest_12345678));
+    it('should return false if there is no staff number in the context', () => {
+      const noAuthContextRequest: APIGatewayProxyEvent = {
+        ...dummyApigwEvent,
+        // @ts-ignore
+        requestContext: {},
+      };
+      const res = jwtVerificationSvc.verifyRequest(noAuthContextRequest, getStaffIdFromTest(sampleTest_12345678));
+      expect(res).toEqual(false);
+    });
+    it('should return false if the staff number in the request context doesnt match the compared staff number', () => {
+      const nonMatchingRequestContext: APIGatewayProxyEvent = {
+        ...dummyApigwEvent,
+        // @ts-ignore
+        requestContext: {
+          authorizer: {
+            staffNumber: '0000',
+          },
+        },
+      };
+      const res = jwtVerificationSvc.verifyRequest(nonMatchingRequestContext, getStaffIdFromTest(sampleTest_12345678));
+      expect(res).toEqual(false);
+    });
+    it('should return true when the staff number in the request context matches for the provided staff number', () => {
+      const matchingRequestContext: APIGatewayProxyEvent = {
+        ...dummyApigwEvent,
+        // @ts-ignore
+        requestContext: {
+          authorizer: {
+            staffNumber: '12345678',
+          },
+        },
+      };
+      const res = jwtVerificationSvc.verifyRequest(matchingRequestContext, getStaffIdFromTest(sampleTest_12345678));
       expect(res).toEqual(true);
     });
-    it('should return false if employeeId and JWT dont match', () => {
-      const res = jwtVerificationSvc.verifyRequest(dummyApigwEvent.headers, getStaffIdFromTest(sampleTest_87654321));
-      expect(res).toEqual(false);
-    });
-    it('should return false if missing employeeId from JWT', () => {
-      dummyApigwEvent.headers.Authorization = null;
-      const res = jwtVerificationSvc.verifyRequest(dummyApigwEvent.headers, getStaffIdFromTest(sampleTest_87654321));
-      expect(res).toEqual(false);
-    });
-    it('should return false if missing staffId from body', () => {
-      const res = jwtVerificationSvc.verifyRequest(dummyApigwEvent.headers, getStaffIdFromTest(sampleTest_empty));
-      expect(res).toEqual(false);
-    });
   });
 
-  describe('getEmployeeIdFromToken', () => {
-    it('should return null if token is null', () => {
-      const res = getEmployeeIdFromToken(null);
-      expect(res).toEqual(null);
-    });
-    it('should return null if EMPLOYEE_ID_EXT_KEY is null', () => {
-      process.env.EMPLOYEE_ID_EXT_KEY = null;
-      const res = getEmployeeIdFromToken(sampleToken_12345678);
-      expect(res).toEqual(null);
-    });
-  });
-
-  describe('getEmployeeIdStringProperty', () => {
-    it('should return null if employeeId is null', () => {
-      const res = getEmployeeIdStringProperty(null);
-      expect(res).toEqual(null);
-    });
-    it('should return null if employeeId is a number', () => {
-      const res = getEmployeeIdStringProperty(1234567890);
-      expect(res).toEqual(null);
-    });
-    it('should return null if employeeId is an empty string', () => {
-      const res = getEmployeeIdStringProperty(' ');
-      expect(res).toEqual(null);
-    });
-    it('should return the employeeId if it is valid', () => {
-      const res = getEmployeeIdStringProperty('1234567890');
-      expect(res).toEqual('1234567890');
-    });
-  });
-
-  describe('getEmployeeIdFromArray', () => {
-    it('should return the first value of the array', () => {
-      const exampleArr = ['first', 'second', 'third'];
-      const resp = getEmployeeIdFromArray(exampleArr);
-      expect(resp).toEqual('first');
-    });
-    it('should return null if empty array', () => {
-      const exampleArr = [];
-      const rtn = getEmployeeIdFromArray(exampleArr);
-      expect(rtn).toBeNull();
-    });
-  });
 });

--- a/src/functions/postResult/application/jwt-verification-service.ts
+++ b/src/functions/postResult/application/jwt-verification-service.ts
@@ -1,21 +1,12 @@
-import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 import * as logger from '../../../common/application/utils/logger';
-import jwtDecode = require('jwt-decode');
-import { getEmployeeIdFromToken } from '../../../common/application/utils/getEmployeeId';
+import { getEmployeeIdFromRequestContext } from '../../../common/application/utils/getEmployeeId';
+import { APIGatewayProxyEvent } from 'aws-lambda';
 
-export const verifyRequest = (headers: { [key: string]: string }, staffId: string): boolean => {
-
-  if (staffId === null) {
-    logger.warn('No staffId found in the test data');
-    return false;
-  }
-  const employeeId = getEmployeeIdFromToken(headers.Authorization);
+export const verifyRequest = (request: APIGatewayProxyEvent, staffId: string): boolean => {
+  const employeeId = getEmployeeIdFromRequestContext(request.requestContext);
   if (employeeId === null) {
-    logger.warn(`No valid authorisation token in request ${employeeId}`);
+    logger.warn('No employee ID found in request context');
     return false;
   }
-  if (employeeId === staffId) {
-    return true;
-  }
-  return false;
+  return employeeId === staffId;
 };

--- a/src/functions/postResult/framework/handler.ts
+++ b/src/functions/postResult/framework/handler.ts
@@ -31,7 +31,7 @@ export async function handler(event: APIGatewayProxyEvent, fnCtx: Context): Prom
     return createResponse({}, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
-  if (!verifyRequest(event.headers, getStaffIdFromTest(testResult))) {
+  if (!verifyRequest(event, getStaffIdFromTest(testResult))) {
     return createResponse({ message: 'EmployeeId and staffId do not match' }, HttpStatus.UNAUTHORIZED);
   }
 

--- a/src/functions/searchResults/framework/handler.ts
+++ b/src/functions/searchResults/framework/handler.ts
@@ -7,7 +7,7 @@ import { bootstrapConfig } from '../../../common/framework/config/config';
 import joi from '@hapi/joi';
 import { QueryParameters } from '../domain/query_parameters';
 import { SearchResultTestSchema } from '@dvsa/mes-search-schema/index';
-import { getEmployeeIdFromToken } from '../../../common/application/utils/getEmployeeId';
+import { getEmployeeIdFromRequestContext } from '../../../common/application/utils/getEmployeeId';
 import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 import { TestResultRecord } from '../../../common/domain/test-results';
 
@@ -17,7 +17,7 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
     // TODO: Retrieve isLDTM value from fnCtx for LDTM searches
     // Temporary workaround having isLDTM as a parameter
 
-    const queryParameters : QueryParameters = new QueryParameters();
+    const queryParameters: QueryParameters = new QueryParameters();
 
     if (!event.queryStringParameters) {
       return createResponse('Query parameters have to be supplied', HttpStatus.BAD_REQUEST);
@@ -55,9 +55,9 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
 
     const parametersSchema = joi.object().keys({
       startDate: joi.string().regex(/([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/).optional()
-          .label('Please provide a valid date with the format \'YYYY-MM-DD\''),
+        .label('Please provide a valid date with the format \'YYYY-MM-DD\''),
       endDate: joi.string().regex(/([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/).optional()
-          .label('Please provide a valid date with the format \'YYYY-MM-DD\''),
+        .label('Please provide a valid date with the format \'YYYY-MM-DD\''),
       driverId: joi.string().alphanum().max(16).optional(),
       staffNumber: joi.string().alphanum().optional(),
       dtcCode: joi.string().alphanum().optional(),
@@ -100,14 +100,14 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
           return createResponse(`DE is not permitted to use the parameter ${key}`, HttpStatus.BAD_REQUEST);
         }
       }
-      const staffNumber = getEmployeeIdFromToken(event.headers.Authorization);
+      const staffNumber = getEmployeeIdFromRequestContext(event.requestContext);
       queryParameters.staffNumber = staffNumber;
     }
 
-    const result : TestResultRecord[] = await getConciseSearchResults(queryParameters);
+    const result: TestResultRecord[] = await getConciseSearchResults(queryParameters);
 
     const results: StandardCarTestCATBSchema[] = result.map(row => row.test_result);
-    const condensedTestResult: SearchResultTestSchema [] = [];
+    const condensedTestResult: SearchResultTestSchema[] = [];
 
     for (const testResultRow of results) {
       const appRef = testResultRow.journalData.applicationReference;


### PR DESCRIPTION
# Description and relevant Jira numbers
* As per https://github.com/dvsa/mes-custom-authorizer/pull/24, the authenticated staff number is now in the request context
* Get the staff number from this context rather than by decoding the JWT
* Remove explicit dependency on `@types/jwt-decode`

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA