### PR TITLE
MES-3032: Return 404 when updateUploadStatus can't update a single record

### DIFF
--- a/src/functions/updateUploadStatus/application/__tests__/update-upload-service.spec.ts
+++ b/src/functions/updateUploadStatus/application/__tests__/update-upload-service.spec.ts
@@ -1,0 +1,40 @@
+import * as database from '../../../../common/framework/mysql/database';
+import { Mock } from 'typemoq';
+import { updateUpload } from '../update-upload-service';
+
+describe('UpdateUploadService', () => {
+  const moqGetConnection = Mock.ofInstance(database.getConnection);
+  const connectionPromiseStub = jasmine.createSpyObj('promise', ['query']);
+  const connectionStub = {
+    promise: () => connectionPromiseStub,
+    end: jasmine.createSpy('end'),
+    rollback: jasmine.createSpy('rollback'),
+  };
+
+  beforeEach(() => {
+    moqGetConnection.reset();
+
+    moqGetConnection.setup(x => x()).returns(() => connectionStub);
+
+    spyOn(database, 'getConnection').and.callFake(moqGetConnection.object);
+  });
+
+  it('should return successfully when a single record is updated', async () => {
+    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ changedRows: 1 }]));
+
+    await updateUpload(123, '');
+  });
+
+  it('should throw an error when no records are updated', async () => {
+    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ changedRows: 0 }]));
+
+    try {
+      await updateUpload(123, '');
+    } catch (err) {
+      expect(connectionStub.rollback).toHaveBeenCalled();
+      return;
+    }
+    fail('should have thrown due to not exactly one record update');
+  });
+
+});

--- a/src/functions/updateUploadStatus/application/update-upload-service.ts
+++ b/src/functions/updateUploadStatus/application/update-upload-service.ts
@@ -1,16 +1,25 @@
 import * as mysql from 'mysql2';
 import { getConnection } from '../../../common/framework/mysql/database';
 import { updateUploadStatus } from '../framework/database/query-builder';
+import { InconsistentUpdateError } from '../domain/InconsistentUpdateError';
+import { error } from '@dvsa/mes-microservice-common/application/utils/logger';
 
 export const updateUpload = async (id: number, body: any): Promise<void> => {
 
   const connection: mysql.Connection = getConnection();
 
   try {
-    await connection.promise().query(updateUploadStatus(id, body));
+    const [update] = await connection.promise().query(updateUploadStatus(id, body));
+    // PK should prevent more than 1 record being updated, assume it's 0
+    if (update.changedRows !== 1) {
+      throw new InconsistentUpdateError();
+    }
   } catch (err) {
     connection.rollback();
-    console.log(err);
+    if (err instanceof InconsistentUpdateError) {
+      throw err;
+    }
+    error(err);
   } finally {
     connection.end();
   }

--- a/src/functions/updateUploadStatus/domain/InconsistentUpdateError.ts
+++ b/src/functions/updateUploadStatus/domain/InconsistentUpdateError.ts
@@ -1,0 +1,10 @@
+/**
+ * Describes the scenario where an attempt was made to update a single upload status,
+ * but a single record was not updated.
+ */
+export class InconsistentUpdateError extends Error {
+  constructor() {
+    super('Failed to update a single UPLOAD_QUEUE record');
+    Object.setPrototypeOf(this, InconsistentUpdateError.prototype);
+  }
+}

--- a/src/functions/updateUploadStatus/framework/__tests__/handler.spec.ts
+++ b/src/functions/updateUploadStatus/framework/__tests__/handler.spec.ts
@@ -1,11 +1,10 @@
 import { APIGatewayEvent, Context } from 'aws-lambda';
-import {
-  handler,
-} from '../handler';
+import { handler } from '../handler';
 const lambdaTestUtils = require('aws-lambda-test-utils');
 import { Mock, It } from 'typemoq';
 import * as configSvc from '../../../../common/framework/config/config';
 import * as updateUploadSvc from '../../application/update-upload-service';
+import { InconsistentUpdateError } from '../../domain/InconsistentUpdateError';
 
 describe('updateUploadStatus handler', () => {
   let dummyApigwEvent: APIGatewayEvent;
@@ -15,14 +14,16 @@ describe('updateUploadStatus handler', () => {
   const moqUpdateUploadSvc = Mock.ofInstance(updateUploadSvc.updateUpload);
 
   beforeEach(() => {
+    moqUpdateUploadSvc.reset();
+
     dummyApigwEvent = lambdaTestUtils.mockEventCreator.createAPIGatewayEvent({});
     dummyContext = lambdaTestUtils.mockContextCreator(() => null);
 
     spyOn(configSvc, 'bootstrapConfig').and.callFake(moqBootstrapConfig.object);
+    spyOn(updateUploadSvc, 'updateUpload').and.callFake(moqUpdateUploadSvc.object);
   });
 
   it('should respond with a CREATED response if provided a valid body and app-ref', async () => {
-    spyOn(updateUploadSvc, 'updateUpload').and.callFake(moqUpdateUploadSvc.object);
     moqUpdateUploadSvc.setup(x => x(It.isAny(), It.isAny())).returns(() => Promise.resolve());
 
     dummyApigwEvent.pathParameters['app-ref'] = '1234';
@@ -76,14 +77,19 @@ describe('updateUploadStatus handler', () => {
       .toBe(`Error application reference is NaN: ${dummyApigwEvent.pathParameters['app-ref']}`);
   });
 
-  it('should send a INTERNAL_SERVER_ERROR response if missing a field', async () => {
+  it('should send NOT_FOUND when update service throws InconsistentUpdateError', async () => {
+    moqUpdateUploadSvc.setup(x => x(It.isAny(), It.isAny())).throws(new InconsistentUpdateError());
     dummyApigwEvent.pathParameters['app-ref'] = '1234';
     dummyApigwEvent.body = JSON.stringify({
-      retry_count: 15,
+      state: 'ACCEPTED',
+      retry_count: 12,
+      staff_number: '1234567890',
+      error_message: null,
+      interface: 'TARS',
     });
+
     const res = await handler(dummyApigwEvent, dummyContext);
-    expect(res.statusCode).toEqual(500);
-    expect(JSON.parse(res.body).message)
-      .toBe(`Error updating the status in UUS of Reference Number: ${dummyApigwEvent.pathParameters['app-ref']}`);
+
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/src/functions/updateUploadStatus/framework/handler.ts
+++ b/src/functions/updateUploadStatus/framework/handler.ts
@@ -5,9 +5,12 @@ import { HttpStatus } from '../../../common/application/api/HttpStatus';
 import { bootstrapConfig } from '../../../common/framework/config/config';
 import { isNullOrBlank } from '../../../functions/postResult/framework/handler';
 import { updateUpload } from '../application/update-upload-service';
+import { error, warn, bootstrapLogging } from '@dvsa/mes-microservice-common/application/utils/logger';
+import { InconsistentUpdateError } from '../domain/InconsistentUpdateError';
 
 export async function handler(event: APIGatewayProxyEvent, fnCtx: Context): Promise<Response> {
 
+  bootstrapLogging('update-upload-status', event);
   await bootstrapConfig();
 
   let body: string;
@@ -27,14 +30,21 @@ export async function handler(event: APIGatewayProxyEvent, fnCtx: Context): Prom
   try {
     body = JSON.parse(event.body);
   } catch (err) {
-    console.log(err);
+    error('Failure parsing request body', event.body);
     return createResponse({ message: 'Error parsing request body into JSON' }, HttpStatus.BAD_REQUEST);
   }
 
   try {
     await updateUpload(appRef, body);
   } catch (err) {
-    console.log(err);
+    if (err instanceof InconsistentUpdateError) {
+      warn('InconsistentUpdateError', err);
+      return createResponse(
+        { message: `Failed to update a single record for application reference ${appRef}` },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+    error(err);
     return createResponse(
       { message: `Error updating the status in UUS of Reference Number: ${appRef}` }, HttpStatus.INTERNAL_SERVER_ERROR);
   }


### PR DESCRIPTION
# Description and relevant Jira numbers
* `updateUploadStatus` Lambda was not checking the number of records being updated
* Rollback the change when the number of changed rows is not 1
* Respond 404 to indicate the single record specified in the event could not be found

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA