### PR TITLE
MES-3119: Fix issues with postResult statuses (#56)

### DIFF
--- a/spec/infra/010-schema.sql
+++ b/spec/infra/010-schema.sql
@@ -3,11 +3,10 @@ CREATE TABLE RESULT_STATUS (
   result_status_name VARCHAR(10) NOT NULL
 );
 INSERT INTO RESULT_STATUS (id, result_status_name) VALUES
-  (0,'ACCEPTED'),
-  (1,'PROCESSING'),
-  (2,'PROCESSED'),
-  (3,'PENDING'),
-  (4,'ERROR');
+  (0,'PROCESSING'),
+  (1,'PROCESSED'),
+  (2,'PENDING'),
+  (3,'ERROR');
 CREATE TABLE PROCESSING_STATUS (
   id TINYINT PRIMARY KEY,
   processing_status_name VARCHAR(10) NOT NULL

--- a/src/functions/postResult/domain/result-status.ts
+++ b/src/functions/postResult/domain/result-status.ts
@@ -1,5 +1,4 @@
 export enum ResultStatus {
-  ACCEPTED,
   PROCESSING,
   PROCESSED,
   PENDING,

--- a/src/functions/postResult/framework/database/__tests__/query-builder.spec.ts
+++ b/src/functions/postResult/framework/database/__tests__/query-builder.spec.ts
@@ -27,5 +27,10 @@ describe('QueryBuilder', () => {
       const result = buildTestResultInsert(dummyTestResult, false);
       expect(result).toMatch(/Campbell/);
     });
+    it('should have processing status as the last argument in the INSERT', () => {
+      const result = buildTestResultInsert(dummyTestResult, false);
+      console.log(result);
+      expect(result).toMatch(/0\)/);
+    });
   });
 });

--- a/src/functions/postResult/framework/database/query-builder.ts
+++ b/src/functions/postResult/framework/database/query-builder.ts
@@ -40,7 +40,7 @@ export const buildTestResultInsert = (test: StandardCarTestCATBSchema, isError: 
     testCentreCostCode,
     driverNumber,
     driverSurname,
-    isError ? ResultStatus.ERROR : ResultStatus.ACCEPTED,
+    isError ? ResultStatus.ERROR : ResultStatus.PROCESSING,
   ];
 
   // Specify that dates should be serialised in UTC.


### PR DESCRIPTION
Cherry-pick from develop for R2: https://github.com/dvsa/mes-result-service/pull/56

* Ensure test result records are created with processing status
* Ignore UPLOAD_QUEUE records if there's a validation error
* Remove RESULT_STATUS ACCEPTED row from retryProcessing integration tests

# Description and relevant Jira numbers

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA