### PR TITLE
MES-3444 - Create Log when max retries have been reached for a record

### DIFF
--- a/src/functions/retryProcessing/application/IRetryProcessor.ts
+++ b/src/functions/retryProcessing/application/IRetryProcessor.ts
@@ -8,6 +8,12 @@ export interface IRetryProcessor {
     tarsRetryCount: number,
   ): Promise<number>;
 
+  processErrorsToLog(
+    rsisRetryCount: number,
+    notifyRetryCount: number,
+    tarsRetryCount: number,
+  ): Promise<void>;
+
   processErrorsToAbort(
     rsisRetryCount: number,
     notifyRetryCount: number,

--- a/src/functions/retryProcessing/application/RetryProcessor.ts
+++ b/src/functions/retryProcessing/application/RetryProcessor.ts
@@ -4,14 +4,16 @@ import {
   buildUpdateErrorsToRetryQuery,
   buildAbortTestsExceeingRetryQuery,
   buildDeleteAcceptedQueueRowsQuery,
+  buildSelectTestsExceedingRetryQuery,
 } from '../framework/database/query-builder';
 import { IRetryProcessor } from './IRetryProcessor';
-import { warn, customMetric } from '@dvsa/mes-microservice-common/application/utils/logger';
+import { warn, customMetric, error } from '@dvsa/mes-microservice-common/application/utils/logger';
 import {
   manualInterventionReprocessUploadQueueQuery,
   manualInterventionUploadQueueReplacementQuery,
   manualInterventionReprocessTestResultQuery,
 } from '../framework/database/query-templates';
+import { FailedUploadQueueResult } from '../domain/query-results-types';
 
 export class RetryProcessor implements IRetryProcessor {
   private connection: mysql.Connection;
@@ -61,6 +63,35 @@ export class RetryProcessor implements IRetryProcessor {
     } catch (err) {
       this.connection.rollback();
       warn('Error caught marking interfaces as ready for retry', err.message);
+    }
+  }
+  async processErrorsToLog(
+    rsisRetryCount: number,
+    notifyRetryCount: number,
+    tarsRetryCount: number,
+  ): Promise<void> {
+    try {
+      const [rows, fields]: [FailedUploadQueueResult[], any] =
+        await this.connection.promise().query(
+          buildSelectTestsExceedingRetryQuery(rsisRetryCount, notifyRetryCount, tarsRetryCount),
+        );
+
+      rows.forEach((row) => {
+        error('A result has reached maximum number of retries', {
+          application_reference: row.application_reference,
+          staff_number: row.staff_number,
+          interface: row.interface,
+          error_message: row.error_message,
+        });
+
+        customMetric(
+          'ResultsNeedingManualIntervention',
+          'The amount of newly processed results which require a manual intervention',
+          rows.length,
+        );
+      });
+    } catch (err) {
+      warn('Error caught selecting which failed upload queue rows to log', err.message);
     }
   }
   async processErrorsToAbort(

--- a/src/functions/retryProcessing/application/RetryProcessor.ts
+++ b/src/functions/retryProcessing/application/RetryProcessor.ts
@@ -14,6 +14,7 @@ import {
   manualInterventionReprocessTestResultQuery,
 } from '../framework/database/query-templates';
 import { FailedUploadQueueResult } from '../domain/query-results-types';
+import { convertInterfaceIdToInterfaceType } from '../domain/interface-types';
 
 export class RetryProcessor implements IRetryProcessor {
   private connection: mysql.Connection;
@@ -80,16 +81,17 @@ export class RetryProcessor implements IRetryProcessor {
         error('A result has reached maximum number of retries', {
           application_reference: row.application_reference,
           staff_number: row.staff_number,
-          interface: row.interface,
+          interface_id: row.interface,
+          interface_name: convertInterfaceIdToInterfaceType(row.interface),
           error_message: row.error_message,
         });
-
-        customMetric(
-          'ResultsNeedingManualIntervention',
-          'The amount of newly processed results which require a manual intervention',
-          rows.length,
-        );
       });
+
+      customMetric(
+        'ResultsNeedingManualIntervention',
+        'The amount of newly processed results which require a manual intervention',
+        rows.length,
+      );
     } catch (err) {
       warn('Error caught selecting which failed upload queue rows to log', err.message);
     }

--- a/src/functions/retryProcessing/domain/RetryProcessingFacade.ts
+++ b/src/functions/retryProcessing/domain/RetryProcessingFacade.ts
@@ -18,7 +18,11 @@ export class RetryProcessingFacade implements IRetryProcessingFacade {
       retryConfig().notifyRetryCount,
       retryConfig().tarsRetryCount,
     );
-
+    await this.retryProcessingRepository.processErrorsToLog(
+      retryConfig().rsisRetryCount,
+      retryConfig().notifyRetryCount,
+      retryConfig().tarsRetryCount,
+    );
     await this.retryProcessingRepository.processErrorsToAbort(
       retryConfig().rsisRetryCount,
       retryConfig().notifyRetryCount,

--- a/src/functions/retryProcessing/domain/interface-types.ts
+++ b/src/functions/retryProcessing/domain/interface-types.ts
@@ -3,3 +3,11 @@ export enum InterfaceTypes {
     RSIS = 'RSIS',
     NOTIFY = 'NOTIFY',
   }
+
+export function convertInterfaceIdToInterfaceType(interfaceId: number) {
+  switch (interfaceId) {
+    case 0: return InterfaceTypes.TARS;
+    case 1: return InterfaceTypes.RSIS;
+    case 2: return InterfaceTypes.NOTIFY;
+  }
+}

--- a/src/functions/retryProcessing/domain/query-results-types.ts
+++ b/src/functions/retryProcessing/domain/query-results-types.ts
@@ -1,0 +1,6 @@
+export interface FailedUploadQueueResult {
+  application_reference: number;
+  staff_number: string;
+  interface: number;
+  error_message: string;
+}

--- a/src/functions/retryProcessing/framework/database/__tests__/query-builder.spec.ts
+++ b/src/functions/retryProcessing/framework/database/__tests__/query-builder.spec.ts
@@ -2,6 +2,7 @@ import {
   buildUpdateErrorsToRetryQuery,
   buildAbortTestsExceeingRetryQuery,
   buildDeleteAcceptedQueueRowsQuery,
+  buildSelectTestsExceedingRetryQuery,
 } from '../query-builder';
 
 describe('QueryBuilder', () => {
@@ -41,6 +42,19 @@ describe('QueryBuilder', () => {
       const result = buildDeleteAcceptedQueueRowsQuery(30);
       // /AND u.timestamp < \'(9999-99-99 99:99:99`')/
       expect(result).toMatch(/AND timestamp < \'\d\d\d\d\-\d\d\-\d\d/);
+    });
+  });
+
+  describe('buildSelectTestsExceedingRetryQuery', () => {
+    it('should have the retry count in the SELECT', () => {
+      const result = buildSelectTestsExceedingRetryQuery(9, 9, 9);
+      expect(result).toMatch(/AND uq.retry_count >= 9/);
+    });
+    it('should have the interface type in the SELECT', () => {
+      const result = buildSelectTestsExceedingRetryQuery(9, 9, 9);
+      expect(result).toMatch(/WHERE interface_type_name = 'RSIS'/);
+      expect(result).toMatch(/WHERE interface_type_name = 'NOTIFY'/);
+      expect(result).toMatch(/WHERE interface_type_name = 'TARS'/);
     });
   });
 

--- a/src/functions/retryProcessing/framework/database/query-builder.ts
+++ b/src/functions/retryProcessing/framework/database/query-builder.ts
@@ -3,6 +3,7 @@ import {
   updateErrorsToRetryQueryTemplate,
   updateErrorsToAbortQueryTemplate as abortTestsExceedingRetryQueryTemplate,
   deleteAccepetedUploadsQuery,
+  selectErrorsWhichWillBeAbortedTemplate,
 } from './query-templates';
 import * as mysql from 'mysql2';
 import moment = require('moment');
@@ -27,6 +28,22 @@ export const buildUpdateErrorsToRetryQuery = (
   updateErrorsToRetryQueryTemplate,
   [rsisRetryCount, notifyRetryCount, tarsRetryCount],
 );
+
+/**
+ * Builds query to select all UPLOAD_QUEUE records that have exceeded the retry limit where the TEST_RESULT
+ * record is in the Processing state.
+ * @param rsisRetryCount
+ * @param notifyRetryCount
+ * @param tarsRetryCount
+ */
+export const buildSelectTestsExceedingRetryQuery = (
+  rsisRetryCount: number,
+  notifyRetryCount: number,
+  tarsRetryCount: number,
+  ) => mysql.format(
+    selectErrorsWhichWillBeAbortedTemplate,
+    [rsisRetryCount, notifyRetryCount, tarsRetryCount],
+  );
 
 /**
  * Builds query to update TEST_RESULT record to ERROR where there are interfaces that exceeded

--- a/src/functions/retryProcessing/framework/database/query-templates.ts
+++ b/src/functions/retryProcessing/framework/database/query-templates.ts
@@ -49,6 +49,24 @@ export const updateErrorsToRetryQueryTemplate = `
     uq1.retry_count = uq1.retry_count + 1
 `;
 
+export const selectErrorsWhichWillBeAbortedTemplate = `
+  SELECT DISTINCT uq.application_reference, uq.staff_number, uq.interface, uq.error_message
+  FROM UPLOAD_QUEUE uq
+  JOIN TEST_RESULT tr
+    ON uq.application_reference = tr.application_reference
+    AND uq.staff_number = tr.staff_number
+    AND tr.result_status = (SELECT id FROM RESULT_STATUS WHERE result_status_name = 'PROCESSING')
+  WHERE
+    uq.upload_status = (SELECT id FROM PROCESSING_STATUS WHERE processing_status_name = 'FAILED')
+    AND (
+      (uq.interface = (SELECT id FROM INTERFACE_TYPE WHERE interface_type_name = 'RSIS') AND uq.retry_count >= ?)
+      OR
+      (uq.interface = (SELECT id FROM INTERFACE_TYPE WHERE interface_type_name = 'NOTIFY') AND uq.retry_count >= ?)
+      OR
+      (uq.interface = (SELECT id FROM INTERFACE_TYPE WHERE interface_type_name = 'TARS') AND uq.retry_count >= ?)
+    )
+`;
+
 export const updateErrorsToAbortQueryTemplate = `
   UPDATE TEST_RESULT tr
   JOIN (


### PR DESCRIPTION
# Description and relevant Jira numbers
- New SQL Query to get all records which the retry limit has been reached on and the test result is in the PROCESSING state
- New function to create a log for each item the previous query finds, which runs before the test results are moved into an ERROR state
- Unit tests

Generated error message looks like this:

`2019-09-04T15:21:58.734Z	85c76ad1-987b-406e-9ce9-d005a24065eb
{
    "level": "ERROR",
    "message": "A result has reached maximum number of retries{\"application_reference\":12345644019,\"staff_number\":\"1234567\",\"interface_id\":2,\"interface_name\":\"NOTIFY\",\"error_message\":\"y\"}"
}`

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA