### PR TITLE
Feature mes 3519 fix build issue

### DIFF
--- a/spec/infra/docker-compose.yml
+++ b/spec/infra/docker-compose.yml
@@ -14,4 +14,4 @@ services:
       - './040-test-data-autosave-sproc.sql:/docker-entrypoint-initdb.d/040-test-data-autosave-sproc.sql'
       - './050-autosave-test-data.sql:/docker-entrypoint-initdb.d/050-autosave-test-data.sql'
     ports:
-      - '1234:3306'
+      - '3306:3306'

--- a/src/functions/retryProcessing/application/__tests__/AutosaveErrorsToRetry.int.ts
+++ b/src/functions/retryProcessing/application/__tests__/AutosaveErrorsToRetry.int.ts
@@ -1,5 +1,5 @@
 import * as mysql from 'mysql2';
-import { IRetryProcessor } from '../IretryProcessor';
+import { IRetryProcessor } from '../IRetryProcessor';
 import { RetryProcessor } from '../RetryProcessor';
 import { getAutosaveQueueRecords } from './common/HelperSQLQueries';
 


### PR DESCRIPTION
Build failed due to incorrect casing on module import.
(the module import worked locally so didn't get picked up in the build pre push)