### PR TITLE
Mes 2949 submit incomplete rsis entry

### DIFF
--- a/src/functions/retryProcessing/application/IRetryProcessor.ts
+++ b/src/functions/retryProcessing/application/IRetryProcessor.ts
@@ -23,4 +23,6 @@ export interface IRetryProcessor {
   processSupportInterventions(): Promise<number>;
 
   processOldEntryCleanup(cutOffPointInDays: number): Promise<number>;
+
+  processStalledTestResults(autosaveCutOffPointInDays: number): Promise<number>;
 }

--- a/src/functions/retryProcessing/application/__tests__/AutosaveProcessStalledSubmission.int.ts
+++ b/src/functions/retryProcessing/application/__tests__/AutosaveProcessStalledSubmission.int.ts
@@ -1,0 +1,208 @@
+import { StalledSubmissionTestResultCases, InterfaceIds } from './common/TestEnums';
+import { IRetryProcessor } from '../IRetryProcessor';
+import * as mysql from 'mysql2';
+import { RetryProcessor } from '../RetryProcessor';
+import {
+  insertAutosaveTestResultData,
+  insertAutosaveQueueResultData,
+  deleteAutosaveTestResultData,
+  getAutosaveQueueRecords,
+  getAutosaveTestResultRecords,
+} from '../helpers/autosave-helpers';
+import { ProcessingStatus } from '../../../../common/domain/processing-status';
+import { AutosaveTestData } from '../helpers/mock-test-data';
+import { AutosaveQueueData } from '../mock-queue-data';
+import { UploadStatus } from '../../../../common/domain/upload-status';
+
+describe('AutosaveStalledSubmissionProcessing', () => {
+  const testCases: StalledSubmissionTestResultCases[] = [
+    StalledSubmissionTestResultCases.AutosavedDateInPastNoRsisUpload,
+    StalledSubmissionTestResultCases.AutosavedDateNotInPastNoRsisUpload,
+    StalledSubmissionTestResultCases.NotAutosavedDateInPastNoRsisUpload,
+    StalledSubmissionTestResultCases.NotAutosavedDateNotInPastNoRsisUpload,
+  ];
+
+  let db: mysql.Connection;
+  let retryProcessor: IRetryProcessor;
+
+  beforeAll(() => {
+    db = mysql.createConnection({
+      host: 'localhost',
+      user: 'results_user',
+      database: 'results',
+      password: 'Pa55word1',
+      port: 3306,
+    });
+    retryProcessor = new RetryProcessor(db);
+  });
+
+  beforeEach(async () => {
+    const testResultData = getTestResultData();
+    const queueResultData = getQueueResultData();
+
+    await insertAutosaveTestResultData(db, testResultData);
+    await insertAutosaveQueueResultData(db, queueResultData);
+  });
+
+  afterEach(async () => {
+    await deleteAutosaveTestResultData(db, 'TEST_RESULT', testCases);
+    await deleteAutosaveTestResultData(db, 'UPLOAD_QUEUE', testCases);
+  });
+
+  it('should add one RSIS record for an autosaved record with a date in the past', async () => {
+    const createdRowCount = await retryProcessor.processStalledTestResults(15);
+    const autosaveQueueRecords = await getAutosaveQueueRecords(db);
+
+    expect(createdRowCount).toBe(1);
+
+    expect(autosaveQueueRecords).toContain(
+      {
+        application_reference: StalledSubmissionTestResultCases.AutosavedDateInPastNoRsisUpload,
+        interface: InterfaceIds.TARS,
+        upload_status: UploadStatus.PROCESSING,
+      },
+    );
+    expect(autosaveQueueRecords).toContain(
+      {
+        application_reference: StalledSubmissionTestResultCases.AutosavedDateInPastNoRsisUpload,
+        interface: InterfaceIds.NOTIFY,
+        upload_status: UploadStatus.PROCESSING,
+      },
+    );
+    expect(autosaveQueueRecords).toContain(
+      {
+        application_reference: StalledSubmissionTestResultCases.AutosavedDateInPastNoRsisUpload,
+        interface: InterfaceIds.RSIS,
+        upload_status: UploadStatus.PROCESSING,
+      },
+    );
+
+    expect(autosaveQueueRecords).not.toContain(
+      {
+        application_reference: StalledSubmissionTestResultCases.AutosavedDateNotInPastNoRsisUpload,
+        interface: InterfaceIds.RSIS,
+        upload_status: UploadStatus.PROCESSING,
+      },
+    );
+
+    expect(autosaveQueueRecords).not.toContain(
+      {
+        application_reference: StalledSubmissionTestResultCases.NotAutosavedDateInPastNoRsisUpload,
+        interface: InterfaceIds.RSIS,
+        upload_status: UploadStatus.PROCESSING,
+      },
+    );
+
+    expect(autosaveQueueRecords).not.toContain(
+      {
+        application_reference: StalledSubmissionTestResultCases.NotAutosavedDateNotInPastNoRsisUpload,
+        interface: InterfaceIds.RSIS,
+        upload_status: UploadStatus.PROCESSING,
+      },
+    );
+  });
+});
+
+const getTestResultData = (): AutosaveTestData[] => {
+  return [
+    {
+      applicationReference: StalledSubmissionTestResultCases.AutosavedDateInPastNoRsisUpload,
+      staffNumber: '1',
+      testDate: '2019-09-01',
+      driverSurname: 'Bloggs',
+      resultStatus: ProcessingStatus.PROCESSING,
+      autosave: true,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.AutosavedDateNotInPastNoRsisUpload,
+      staffNumber: '1',
+      driverSurname: 'Bloggs',
+      resultStatus: ProcessingStatus.PROCESSING,
+      autosave: true,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.NotAutosavedDateInPastNoRsisUpload,
+      staffNumber: '1',
+      testDate: '2019-09-01',
+      driverSurname: 'Bloggs',
+      resultStatus: ProcessingStatus.PROCESSING,
+      autosave: false,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.NotAutosavedDateNotInPastNoRsisUpload,
+      staffNumber: '1',
+      driverSurname: 'Bloggs',
+      resultStatus: ProcessingStatus.PROCESSING,
+      autosave: false,
+    },
+  ];
+};
+
+const getQueueResultData = (): AutosaveQueueData[] => {
+  return [
+    {
+      applicationReference: StalledSubmissionTestResultCases.AutosavedDateInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.TARS,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.AutosavedDateInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.NOTIFY,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.AutosavedDateNotInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.TARS,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.AutosavedDateNotInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.NOTIFY,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.NotAutosavedDateInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.TARS,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.NotAutosavedDateInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.NOTIFY,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.NotAutosavedDateNotInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.TARS,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+    {
+      applicationReference: StalledSubmissionTestResultCases.NotAutosavedDateNotInPastNoRsisUpload,
+      staffNumber: '1',
+      interface: InterfaceIds.NOTIFY,
+      uploadStatus: ProcessingStatus.PROCESSING,
+      retryCount: 0,
+      timestamp: null,
+    },
+  ];
+};

--- a/src/functions/retryProcessing/application/__tests__/common/TestEnums.ts
+++ b/src/functions/retryProcessing/application/__tests__/common/TestEnums.ts
@@ -103,3 +103,10 @@ export enum SupportInterventionTestCases {
   AutosaveTarsFailNotifyFail = 84,
   AutosaveTarsFailNotifyAccept = 85,
 }
+
+export enum StalledSubmissionTestResultCases {
+  AutosavedDateInPastNoRsisUpload = 86,
+  AutosavedDateNotInPastNoRsisUpload = 87,
+  NotAutosavedDateInPastNoRsisUpload = 88,
+  NotAutosavedDateNotInPastNoRsisUpload = 89,
+}

--- a/src/functions/retryProcessing/application/helpers/autosave-helpers.ts
+++ b/src/functions/retryProcessing/application/helpers/autosave-helpers.ts
@@ -21,7 +21,7 @@ export const insertAutosaveTestResultData = (
         item.applicationReference,
         item.staffNumber,
         '{}',
-        new Date().toISOString().slice(0, 10),
+        item.testDate ? item.testDate : new Date().toISOString().slice(0, 10),
         1,
         1,
         `dnum${item.applicationReference}`,

--- a/src/functions/retryProcessing/application/helpers/mock-test-data.ts
+++ b/src/functions/retryProcessing/application/helpers/mock-test-data.ts
@@ -1,6 +1,7 @@
 export class AutosaveTestData {
   applicationReference: number;
   staffNumber: string;
+  testDate?: string;
   driverSurname: string;
   resultStatus: number;
   autosave: boolean;

--- a/src/functions/retryProcessing/domain/RetryProcessingFacade.ts
+++ b/src/functions/retryProcessing/domain/RetryProcessingFacade.ts
@@ -31,5 +31,6 @@ export class RetryProcessingFacade implements IRetryProcessingFacade {
 
     await this.retryProcessingRepository.processSupportInterventions();
     await this.retryProcessingRepository.processOldEntryCleanup(retryConfig().retryCutOffPointDays);
+    await this.retryProcessingRepository.processStalledTestResults(retryConfig().autosaveCutOffPointInDays);
   }
 }

--- a/src/functions/retryProcessing/framework/database/query-builder.ts
+++ b/src/functions/retryProcessing/framework/database/query-builder.ts
@@ -4,6 +4,7 @@ import {
   updateErrorsToAbortQueryTemplate as abortTestsExceedingRetryQueryTemplate,
   deleteAccepetedUploadsQuery,
   selectErrorsWhichWillBeAbortedTemplate,
+  processStalledTestResultsQuery,
 } from './query-templates';
 import * as mysql from 'mysql2';
 import moment = require('moment');
@@ -64,4 +65,9 @@ export const buildAbortTestsExceeingRetryQuery = (
 export const buildDeleteAcceptedQueueRowsQuery = (cutOffPointInDays: number) => {
   const startDate = moment().subtract(cutOffPointInDays, 'days').format('YYYY-MM-DD HH:mm:ss');
   return mysql.format(deleteAccepetedUploadsQuery, [startDate]);
+};
+
+export const buildProcessStalledTestResultsQuery = (autosaveCutOffPointInDays: number) => {
+  const startDate = moment().subtract(autosaveCutOffPointInDays, 'days').format('YYYY-MM-DD');
+  return mysql.format(processStalledTestResultsQuery, [startDate]);
 };

--- a/src/functions/retryProcessing/framework/retryConfig.ts
+++ b/src/functions/retryProcessing/framework/retryConfig.ts
@@ -7,6 +7,7 @@ export type Config = {
   rsisRetryCount: number;
   notifyRetryCount: number;
   tarsRetryCount: number;
+  autosaveCutOffPointInDays: number;
 };
 
 let configuration: Config;
@@ -16,6 +17,7 @@ export const getRetryConfig = async (): Promise<void> => {
     rsisRetryCount: +defaultIfNotPresent(process.env.RSIS_RETRY_COUNT, '3'),
     notifyRetryCount: +defaultIfNotPresent(process.env.NOTIFY_RETRY_COUNT, '3'),
     tarsRetryCount: +defaultIfNotPresent(process.env.TARS_RETRY_COUNT, '3'),
+    autosaveCutOffPointInDays: +defaultIfNotPresent(process.env.AUTOSAVE_CUT_OFF_POINT_IN_DAYS, '15'),
   };
 };
 


### PR DESCRIPTION
# Description and relevant Jira numbers
- `processStalledTestResultsQuery` added to insert `RSIS` records for `test_results` which are `autosaved`, not in the `ACCEPTED` state and have a `test_date` at least 15 days in the past
- This is a forerunner for a subtask within the same ticket (https://jira.dvsacloud.uk/browse/MES-2949) to update the relevant changes in the RSIS MI lambda.
## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA