### PR TITLE
Mes 3632 bump test schema version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
       "dev": true
     },
     "@dvsa/mes-test-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-2.0.3.tgz",
-      "integrity": "sha512-FPwvOkSGsjmyBSIVeJ1GbrKPmJFJ1i4Yea7flcFqK6JtjxttD49/DkdPQV7k3fcSBmLAoXMVUPIibxTuoAR0Mw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.0.0.tgz",
+      "integrity": "sha512-MR4VJR7gsBB5f7rW8d99XAyT8+tlcVJSNDsPjJoeX61WFS1mWN40xyLSO+O8FrpJyXhRSlv+UGDQFjcH4a0T3w==",
       "dev": true
     },
     "@fimbul/bifrost": {
@@ -3219,8 +3219,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3241,14 +3240,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3263,20 +3260,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3393,8 +3387,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3406,7 +3399,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3421,7 +3413,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3429,14 +3420,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3455,7 +3444,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3543,8 +3531,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3556,7 +3543,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3642,8 +3628,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3679,7 +3664,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3699,7 +3683,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3743,14 +3726,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@dvsa/mes-microservice-common": "0.1.7",
     "@dvsa/mes-search-schema": "1.0.3",
-    "@dvsa/mes-test-schema": "2.0.3",
+    "@dvsa/mes-test-schema": "3.0.0",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",

--- a/src/functions/postResult/domain/__tests__/mes-joi-schema-service.spec.ts
+++ b/src/functions/postResult/domain/__tests__/mes-joi-schema-service.spec.ts
@@ -11,6 +11,7 @@ describe('Joi schema validation service', () => {
 
   it('should return a validation error if \'testSlotAttributes.start\' schema validation fails', () => {
     const invalidSchema = {
+      version: '0.0.1',
       activityCode: '1',
       category: 'B',
       journalData: {
@@ -49,6 +50,7 @@ describe('Joi schema validation service', () => {
 
   it('should not return a validation error if \'testSlotAttributes.start\' is valid', () => {
     const invalidSchema = {
+      version: '0.0.1',
       activityCode: '1',
       category: 'B',
       journalData: {
@@ -84,6 +86,7 @@ describe('Joi schema validation service', () => {
 
   it('should return a validation error if required property is missing from schema', () => {
     const invalidSchema = {
+      version: '0.0.1',
       activityCode: '1',
       category: 'B',
       journalData: {

--- a/src/functions/postResult/framework/__tests__/handler.spec.data.ts
+++ b/src/functions/postResult/framework/__tests__/handler.spec.data.ts
@@ -39,6 +39,7 @@ VUQ4QJMUSisGQ9wSBR7GgFuPvKrdIzvi-2dZLcaCazThAsA9XxV1FetdMtFHcX0XiW-FEDfEYZhJoMhj
 sKbh_w';
 
 export const sampleTest_12345678: StandardCarTestCATBSchema = {
+  version: '0.0.1',
   category: null,
   journalData: {
     applicationReference: null,
@@ -58,6 +59,7 @@ export const sampleTest_12345678: StandardCarTestCATBSchema = {
 };
 
 export const sampleTest_87654321: StandardCarTestCATBSchema = {
+  version: '0.0.1',
   category: null,
   journalData: {
     applicationReference: null,
@@ -77,6 +79,7 @@ export const sampleTest_87654321: StandardCarTestCATBSchema = {
 };
 
 export const sampleTest_empty: StandardCarTestCATBSchema = {
+  version: '0.0.1',
   category: null,
   journalData: {
     applicationReference: null,

--- a/src/functions/postResult/framework/database/__tests__/query-builder.spec.data.ts
+++ b/src/functions/postResult/framework/database/__tests__/query-builder.spec.data.ts
@@ -1,6 +1,7 @@
 import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
 
 export const dummyTestResult: StandardCarTestCATBSchema = {
+  version: '0.0.1',
   category: 'B',
   journalData: {
     examiner: {


### PR DESCRIPTION
# Description and relevant Jira numbers
Use the latest version of the mes test schema, which includes a new version property: https://github.com/dvsa/mes-api-definitions/pull/75

https://jira.dvsacloud.uk/browse/MES-3632

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA