### PR TITLE
MES-5005: Bump mes-test-schema version number to 3.20.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
       "dev": true
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.21.0.tgz",
-      "integrity": "sha512-TzONs2eb1ZMAj+zwjUg6Zm786ojZU/Qc8dhR+1wnT82x1uYYc995xq16LpueP4CypMpsgXHSht7lKg/K7inJLQ==",
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.20.3.tgz",
+      "integrity": "sha512-Y9b+8y9T+hR4fxIKGs4KNbZUZgR0wL8sD8jcjmA9EKc3Sg6yt9uqxGPRxVHMI/IjEbPVGPmGXdsiAwoLFEhDLQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@dvsa/mes-microservice-common": "0.4.0",
     "@dvsa/mes-search-schema": "1.1.0",
-    "@dvsa/mes-test-schema": "3.21.0",
+    "@dvsa/mes-test-schema": "3.20.3",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",


### PR DESCRIPTION
Bump mes-test-schema version to 3.20.3 in order to support correct validation.