### PR TITLE
MES-6084: Upgrading mes-test-schema to version 3.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,9 +161,9 @@
       "dev": true
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.28.0.tgz",
-      "integrity": "sha512-BSuhxpj/LwwVdVtsDxEk5qrjReDfZYa5wpsGqu1wTiA5xOW8LjViHKXPJNzHptG3HqPFl+l1itcypLBzze+CWQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.31.0.tgz",
+      "integrity": "sha512-da8ggSPk2rlF0hmmM3TJr4udR+S317XjDU7R2dUi7sYGgv/Si/xk0vJAyEYhkejVqh6xxmJmHng7VnZyIIfXDA==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@dvsa/mes-microservice-common": "0.7.0",
     "@dvsa/mes-search-schema": "1.1.2",
-    "@dvsa/mes-test-schema": "3.28.0",
+    "@dvsa/mes-test-schema": "3.31.0",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",


### PR DESCRIPTION
Upgrading microservice to use the latest test schema