### PR TITLE
MES-6736 add optional exclusion of auto saved tests

### DIFF
--- a/src/functions/searchResults/domain/query_parameters.ts
+++ b/src/functions/searchResults/domain/query_parameters.ts
@@ -6,5 +6,5 @@ export class QueryParameters {
   driverNumber: string;
   dtcCode: string;
   applicationReference: string;
-
+  excludeAutoSavedTests: string;
 }

--- a/src/functions/searchResults/framework/__tests__/handler.spec.data.ts
+++ b/src/functions/searchResults/framework/__tests__/handler.spec.data.ts
@@ -46,6 +46,7 @@ export const queryParameter: QueryParameters = {
   driverNumber: 'SHAWX885220A99HC',
   applicationReference: '1234570231',
   dtcCode: 'EXTC1',
+  excludeAutoSavedTests: 'false',
 };
 
 export const queryParameterWith8DigitAppRef: QueryParameters = {
@@ -55,6 +56,7 @@ export const queryParameterWith8DigitAppRef: QueryParameters = {
   driverNumber: 'SHAWX885220A99HC',
   applicationReference: '12345702',
   dtcCode: 'EXTC1',
+  excludeAutoSavedTests: 'false',
 };
 
 export const testResultResponse = [

--- a/src/functions/searchResults/framework/__tests__/handler.spec.ts
+++ b/src/functions/searchResults/framework/__tests__/handler.spec.ts
@@ -82,6 +82,7 @@ describe('searchResults handler', () => {
       dummyApigwEvent.queryStringParameters['dtcCode'] = queryParameter.dtcCode;
       dummyApigwEvent.queryStringParameters['staffNumber'] = queryParameter.staffNumber;
       dummyApigwEvent.queryStringParameters['applicationReference'] = queryParameter.applicationReference;
+      dummyApigwEvent.queryStringParameters['excludeAutoSavedTests'] = queryParameter.excludeAutoSavedTests;
       moqSearchResults.setup(x => x(It.isAny())).returns(() => Promise.resolve(testResult));
       const resp = await handler(dummyApigwEvent, dummyContext);
       expect(resp.statusCode).toBe(200);
@@ -100,6 +101,8 @@ describe('searchResults handler', () => {
       dummyApigwEvent.queryStringParameters['driverNumber'] = queryParameterWith8DigitAppRef.driverNumber;
       dummyApigwEvent.queryStringParameters['dtcCode'] = queryParameterWith8DigitAppRef.dtcCode;
       dummyApigwEvent.queryStringParameters['staffNumber'] = queryParameterWith8DigitAppRef.staffNumber;
+      dummyApigwEvent.queryStringParameters['excludeAutoSavedTests'] =
+        queryParameterWith8DigitAppRef.excludeAutoSavedTests;
       dummyApigwEvent.queryStringParameters['applicationReference'] = queryParameterWith8DigitAppRef
         .applicationReference;
       moqSearchResults.setup(x => x(It.isAny())).returns(() => Promise.resolve(testResult));

--- a/src/functions/searchResults/framework/database/__tests__/query-builder.spec.data.ts
+++ b/src/functions/searchResults/framework/database/__tests__/query-builder.spec.data.ts
@@ -7,4 +7,5 @@ export const queryParameter: QueryParameters = {
   driverNumber: 'SHAWX885220A99HC',
   applicationReference: '1234570231',
   dtcCode: 'EXTC1',
+  excludeAutoSavedTests: 'true',
 };

--- a/src/functions/searchResults/framework/database/query-builder.ts
+++ b/src/functions/searchResults/framework/database/query-builder.ts
@@ -23,6 +23,10 @@ export const getConciseSearchResultsFromSearchQuery = (queryParameters: QueryPar
     parameterArray.push(queryParameters.staffNumber);
   }
 
+  if (queryParameters.excludeAutoSavedTests === 'true') {
+    queries.push('autosave <> 1');
+  }
+
   if (queryParameters.applicationReference) {
     if (queryParameters.applicationReference.toString().length === 8) {
       /*

--- a/src/functions/searchResults/framework/handler.ts
+++ b/src/functions/searchResults/framework/handler.ts
@@ -42,6 +42,10 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
     if (event.queryStringParameters.applicationReference) {
       queryParameters.applicationReference = event.queryStringParameters.applicationReference;
     }
+    if (event.queryStringParameters.excludeAutoSavedTests) {
+      queryParameters.excludeAutoSavedTests = event.queryStringParameters.excludeAutoSavedTests === 'true' ?
+        'true' : 'false';
+    }
 
     if (Object.keys(queryParameters).length === 0) {
       return createResponse('Query parameters have to be supplied', HttpStatus.BAD_REQUEST);
@@ -56,6 +60,7 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
       staffNumber: joi.number().optional(),
       dtcCode: joi.string().alphanum().optional(),
       appRef: joi.number().max(1000000000000).optional(),
+      excludeAutoSavedTests: joi.string().optional(),
     });
 
     const validationResult =
@@ -66,6 +71,7 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
         appRef: queryParameters.applicationReference,
         startDate: queryParameters.startDate,
         endDate: queryParameters.endDate,
+        excludeAutoSavedTests: queryParameters.excludeAutoSavedTests,
       },           parametersSchema);
 
     if (validationResult.error) {
@@ -74,12 +80,12 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
 
     const ldtmPermittedQueries = [
       'startDate', 'staffNumber', 'endDate', 'driverNumber',
-      'dtcCode', 'applicationReference',
+      'dtcCode', 'applicationReference', 'excludeAutoSavedTests',
     ];
 
-    const dePermittedQueries = ['driverNumber', 'applicationReference'];
+    const dePermittedQueries = ['driverNumber', 'applicationReference', 'excludeAutoSavedTests'];
 
-    const dlgPermittedQueries = ['driverNumber', 'applicationReference'];
+    const dlgPermittedQueries = ['driverNumber', 'applicationReference', 'excludeAutoSavedTests'];
 
     const isLDTM = event.requestContext.authorizer.examinerRole === UserRole.LDTM;
 


### PR DESCRIPTION
# Description and relevant Jira numbers
[MES-6736](https://jira.dvsacloud.uk/browse/MES-6736)
- Adds option to filter autosaved tests via `excludeAutoSavedTests` param
- Resolves bug whereby auto saved results cannot be written up from journal if completed tests refreshed

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA