### PR TITLE
MES-6194: Enable DLG advanced search

### DIFF
--- a/src/functions/searchResults/framework/__tests__/handler.spec.ts
+++ b/src/functions/searchResults/framework/__tests__/handler.spec.ts
@@ -114,37 +114,29 @@ describe('searchResults handler', () => {
   });
 
   describe('request made by DLG', () => {
-    it('should fail with bad request when using forbidden query params', async () => {
+    beforeEach(() => {
       dummyApigwEvent.requestContext.authorizer = {
         examinerRole: UserRole.DLG,
       };
+      moqSearchResults.setup(x => x(It.isAny())).returns(() => Promise.resolve(testResult));
+    });
 
-      const wrongQueryParameterKey = 'startDate';
-
-      dummyApigwEvent.queryStringParameters[wrongQueryParameterKey] = queryParameter.startDate;
+    it('should get relevant results when searching by correct staff number reference', async () => {
+      dummyApigwEvent.queryStringParameters['staffNumber'] = queryParameter.staffNumber;
       const resp = await handler(dummyApigwEvent, dummyContext);
-      expect(resp.statusCode).toBe(400);
-      expect(JSON.parse(resp.body))
-        .toBe(`DLG is not permitted to use the parameter ${wrongQueryParameterKey}`);
+      expect(resp.statusCode).toBe(200);
+      expect(JSON.parse(resp.body)).toEqual(testResultResponse);
     });
 
     it('should get relevant results when searching by correct application reference', async () => {
-      dummyApigwEvent.requestContext.authorizer = {
-        examinerRole: UserRole.DLG,
-      };
       dummyApigwEvent.queryStringParameters['applicationReference'] = queryParameter.applicationReference;
-      moqSearchResults.setup(x => x(It.isAny())).returns(() => Promise.resolve(testResult));
       const resp = await handler(dummyApigwEvent, dummyContext);
       expect(resp.statusCode).toBe(200);
       expect(JSON.parse(resp.body)).toEqual(testResultResponse);
     });
 
     it('should get relevant results when searching by correct driver number', async () => {
-      dummyApigwEvent.requestContext.authorizer = {
-        examinerRole: UserRole.DLG,
-      };
       dummyApigwEvent.queryStringParameters['driverNumber'] = queryParameter.driverNumber;
-      moqSearchResults.setup(x => x(It.isAny())).returns(() => Promise.resolve(testResult));
       const resp = await handler(dummyApigwEvent, dummyContext);
       expect(resp.statusCode).toBe(200);
       expect(JSON.parse(resp.body)).toEqual(testResultResponse);

--- a/src/functions/searchResults/framework/handler.ts
+++ b/src/functions/searchResults/framework/handler.ts
@@ -57,7 +57,7 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
       endDate: joi.string().regex(/([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/).optional()
         .label('Please provide a valid date with the format \'YYYY-MM-DD\''),
       driverId: joi.string().alphanum().max(16).optional(),
-      staffNumber: joi.number().optional(),
+      staffNumber: joi.string().alphanum().optional(),
       dtcCode: joi.string().alphanum().optional(),
       appRef: joi.number().max(1000000000000).optional(),
       excludeAutoSavedTests: joi.string().optional(),
@@ -96,20 +96,14 @@ export async function handler(event: APIGatewayEvent, fnCtx: Context): Promise<R
     const searchingForOwnTest = isSearchingForOwnTests(queryParameters, staffNumber);
 
     // This is to be safe, incase new parameters are added for DE only in the future
-    if (isLDTM || searchingForOwnTest) {
+    if (isDLG || isLDTM || searchingForOwnTest) {
       for (const key in queryParameters) {
         if (!ldtmPermittedQueries.includes(key)) {
           const role = isLDTM ? 'LDTM' : 'User searching for own test';
           return createResponse(`${role} is not permitted to use the parameter ${key}`, HttpStatus.BAD_REQUEST);
         }
       }
-    } else if (isDLG) {
-      for (const key in queryParameters) {
-        if (!dlgPermittedQueries.includes(key)) {
-          return createResponse(`DLG is not permitted to use the parameter ${key}`, HttpStatus.BAD_REQUEST);
-        }
-      }
-    } else if (!isLDTM && !isDLG) {
+    }  else if (!isLDTM && !isDLG) {
       for (const key in queryParameters) {
         if (!dePermittedQueries.includes(key)) {
           return createResponse(`DE is not permitted to use the parameter ${key}`, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
# Description and relevant Jira numbers

- Updates staff no parameter to allow any alphanumeric value (previously numeric only) to enable searching for completed delegated examiner tests
- Amends access to advanced search features to allow users with delegated rekey role (`DLG`) in addition to those with LDTM role

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA