### PR TITLE
Mes 3853 delete test results

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -47,6 +47,13 @@ functions:
           path: test-result/retry
           method: get
 
+  deleteTestResultRecord:
+    handler: src/functions/deleteTestResultRecord/framework/handler.handler
+    events:
+      - http:
+          path: test-result/delete
+          method: put
+
 custom:
   dynamodb:
     start:

--- a/src/functions/deleteTestResultRecord/application/__tests__/delete-testResult-Service.spec.ts
+++ b/src/functions/deleteTestResultRecord/application/__tests__/delete-testResult-Service.spec.ts
@@ -1,12 +1,6 @@
 import * as database from '../../../../common/framework/mysql/database';
 import { Mock } from 'typemoq';
 import { deleteTestResult } from '../delete-testResult-service';
-import { SubmissionOutcome } from '../../domain/SubmissionOutcome';
-
-const mockSubmissionOutcome: SubmissionOutcome = {
-  error_message: null,
-  retry_count: 0,
-};
 
 describe('DeleteTestResultService', () => {
   const moqGetConnection = Mock.ofInstance(database.getConnection);
@@ -26,15 +20,15 @@ describe('DeleteTestResultService', () => {
   });
 
   it('should return successfully when a single record is deleted', async () => {
-    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ changedRows: 1 }]));
-    await deleteTestResult(mockSubmissionOutcome);
+    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ affectedRows: 1 }]));
+    await deleteTestResult();
   });
 
   it('should throw a warning when no records are deleted', async () => {
-    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ changedRows: 0 }]));
+    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ affectedRows: 0 }]));
 
     try {
-      await deleteTestResult(mockSubmissionOutcome);
+      await deleteTestResult();
     } catch (err) {
       expect(connectionStub.rollback).toHaveBeenCalled();
       return;

--- a/src/functions/deleteTestResultRecord/application/__tests__/delete-testResult-Service.spec.ts
+++ b/src/functions/deleteTestResultRecord/application/__tests__/delete-testResult-Service.spec.ts
@@ -1,0 +1,45 @@
+import * as database from '../../../../common/framework/mysql/database';
+import { Mock } from 'typemoq';
+import { deleteTestResult } from '../delete-testResult-service';
+import { SubmissionOutcome } from '../../domain/SubmissionOutcome';
+
+const mockSubmissionOutcome: SubmissionOutcome = {
+  error_message: null,
+  retry_count: 0,
+};
+
+describe('DeleteTestResultService', () => {
+  const moqGetConnection = Mock.ofInstance(database.getConnection);
+  const connectionPromiseStub = jasmine.createSpyObj('promise', ['query']);
+  const connectionStub = {
+    promise: () => connectionPromiseStub,
+    end: jasmine.createSpy('end'),
+    rollback: jasmine.createSpy('rollback'),
+  };
+
+  beforeEach(() => {
+    moqGetConnection.reset();
+
+    moqGetConnection.setup(x => x()).returns(() => connectionStub);
+
+    spyOn(database, 'getConnection').and.callFake(moqGetConnection.object);
+  });
+
+  it('should return successfully when a single record is deleted', async () => {
+    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ changedRows: 1 }]));
+    await deleteTestResult(mockSubmissionOutcome);
+  });
+
+  it('should throw a warning when no records are deleted', async () => {
+    connectionPromiseStub.query.and.returnValue(Promise.resolve([{ changedRows: 0 }]));
+
+    try {
+      await deleteTestResult(mockSubmissionOutcome);
+    } catch (err) {
+      expect(connectionStub.rollback).toHaveBeenCalled();
+      return;
+    }
+    fail('should have thrown due to no records deleted');
+  });
+
+});

--- a/src/functions/deleteTestResultRecord/application/delete-testResult-service.ts
+++ b/src/functions/deleteTestResultRecord/application/delete-testResult-service.ts
@@ -2,14 +2,13 @@ import * as mysql from 'mysql2';
 import { getConnection } from '../../../common/framework/mysql/database';
 import { deleteTestResultRecord } from '../framework/database/query-builder';
 import { NoDeleteWarning } from '../domain/NoDeleteWarning';
-import { SubmissionOutcome } from '../domain/SubmissionOutcome';
 import { info } from '@dvsa/mes-microservice-common/application/utils/logger';
 
-export const deleteTestResult = async (body: SubmissionOutcome): Promise<void> => {
+export const deleteTestResult = async (): Promise<void> => {
   const connection: mysql.Connection = getConnection();
 
   try {
-    const [deleted] = await connection.promise().query(deleteTestResultRecord(body));
+    const [deleted] = await connection.promise().query(deleteTestResultRecord());
     info('No of records Deleted: ',  deleted.affectedRows);
     if (deleted.affectedRows === 0) {
       throw new NoDeleteWarning();

--- a/src/functions/deleteTestResultRecord/application/delete-testResult-service.ts
+++ b/src/functions/deleteTestResultRecord/application/delete-testResult-service.ts
@@ -1,0 +1,23 @@
+import * as mysql from 'mysql2';
+import { getConnection } from '../../../common/framework/mysql/database';
+import { deleteTestResultRecord } from '../framework/database/query-builder';
+import { NoDeleteWarning } from '../domain/NoDeleteWarning';
+import { SubmissionOutcome } from '../domain/SubmissionOutcome';
+import { info } from '@dvsa/mes-microservice-common/application/utils/logger';
+
+export const deleteTestResult = async (body: SubmissionOutcome): Promise<void> => {
+  const connection: mysql.Connection = getConnection();
+
+  try {
+    const [deleted] = await connection.promise().query(deleteTestResultRecord(body));
+    info('No of records Deleted: ',  deleted.affectedRows);
+    if (deleted.affectedRows === 0) {
+      throw new NoDeleteWarning();
+    }
+  } catch (err) {
+    connection.rollback();
+    throw err;
+  } finally {
+    connection.end();
+  }
+};

--- a/src/functions/deleteTestResultRecord/domain/NoDeleteWarning.ts
+++ b/src/functions/deleteTestResultRecord/domain/NoDeleteWarning.ts
@@ -1,0 +1,9 @@
+/**
+ * Describes the scenario where an attempt was made to delete Test Results
+ */
+export class NoDeleteWarning extends Error {
+  constructor() {
+    super('No records deleted');
+    Object.setPrototypeOf(this, NoDeleteWarning.prototype);
+  }
+}

--- a/src/functions/deleteTestResultRecord/domain/SubmissionOutcome.ts
+++ b/src/functions/deleteTestResultRecord/domain/SubmissionOutcome.ts
@@ -1,0 +1,4 @@
+export interface SubmissionOutcome {
+  retry_count: number;
+  error_message: string | null;
+}

--- a/src/functions/deleteTestResultRecord/domain/SubmissionOutcome.ts
+++ b/src/functions/deleteTestResultRecord/domain/SubmissionOutcome.ts
@@ -1,4 +1,0 @@
-export interface SubmissionOutcome {
-  retry_count: number;
-  error_message: string | null;
-}

--- a/src/functions/deleteTestResultRecord/framework/__tests__/handler.spec.ts
+++ b/src/functions/deleteTestResultRecord/framework/__tests__/handler.spec.ts
@@ -23,40 +23,8 @@ describe('deleteTestResult handler', () => {
     spyOn(deleteTestResultSvc, 'deleteTestResult').and.callFake(moqDeleteTestResultSvc.object);
   });
 
-  it('should respond with a CREATED response if provided a valid body', async () => {
-    moqDeleteTestResultSvc.setup(x => x(It.isAny())).returns(() => Promise.resolve());
-
-    dummyApigwEvent.body = JSON.stringify({
-      retry_count: 12,
-      error_message: null,
-    });
-
-    const res = await handler(dummyApigwEvent, dummyContext);
-    expect(res.statusCode).toEqual(201);
-  });
-
-  it('should send a BAD_REQUEST response if the request body is blank', async () => {
-    dummyApigwEvent.body = '';
-
-    const res = await handler(dummyApigwEvent, dummyContext);
-    expect(res.statusCode).toEqual(400);
-    expect(JSON.parse(res.body).message).toBe('Empty request body');
-  });
-
-  it('should send a BAD_REQUEST response when the body isnt in JSON', async () => {
-    dummyApigwEvent.body = 'this is not json 1234';
-
-    const res = await handler(dummyApigwEvent, dummyContext);
-    expect(res.statusCode).toEqual(400);
-    expect(JSON.parse(res.body).message).toBe('Error parsing request body into JSON');
-  });
-
   it('should send NOT_FOUND when delete testRecord service throws NoDeleteWarning', async () => {
-    moqDeleteTestResultSvc.setup(x => x(It.isAny())).throws(new NoDeleteWarning());
-    dummyApigwEvent.body = JSON.stringify({
-      retry_count: 12,
-      error_message: null,
-    });
+    moqDeleteTestResultSvc.setup(x => x()).throws(new NoDeleteWarning());
 
     const res = await handler(dummyApigwEvent, dummyContext);
 

--- a/src/functions/deleteTestResultRecord/framework/__tests__/handler.spec.ts
+++ b/src/functions/deleteTestResultRecord/framework/__tests__/handler.spec.ts
@@ -1,0 +1,65 @@
+import { APIGatewayEvent, Context } from 'aws-lambda';
+import { handler } from '../handler';
+const lambdaTestUtils = require('aws-lambda-test-utils');
+import { Mock, It } from 'typemoq';
+import * as configSvc from '../../../../common/framework/config/config';
+import * as deleteTestResultSvc from '../../application/delete-testResult-service';
+import { NoDeleteWarning } from '../../domain/NoDeleteWarning';
+
+describe('deleteTestResult handler', () => {
+  let dummyApigwEvent: APIGatewayEvent;
+  let dummyContext: Context;
+
+  const moqBootstrapConfig = Mock.ofInstance(configSvc.bootstrapConfig);
+  const moqDeleteTestResultSvc = Mock.ofInstance(deleteTestResultSvc.deleteTestResult);
+
+  beforeEach(() => {
+    moqDeleteTestResultSvc.reset();
+
+    dummyApigwEvent = lambdaTestUtils.mockEventCreator.createAPIGatewayEvent({});
+    dummyContext = lambdaTestUtils.mockContextCreator(() => null);
+
+    spyOn(configSvc, 'bootstrapConfig').and.callFake(moqBootstrapConfig.object);
+    spyOn(deleteTestResultSvc, 'deleteTestResult').and.callFake(moqDeleteTestResultSvc.object);
+  });
+
+  it('should respond with a CREATED response if provided a valid body', async () => {
+    moqDeleteTestResultSvc.setup(x => x(It.isAny())).returns(() => Promise.resolve());
+
+    dummyApigwEvent.body = JSON.stringify({
+      retry_count: 12,
+      error_message: null,
+    });
+
+    const res = await handler(dummyApigwEvent, dummyContext);
+    expect(res.statusCode).toEqual(201);
+  });
+
+  it('should send a BAD_REQUEST response if the request body is blank', async () => {
+    dummyApigwEvent.body = '';
+
+    const res = await handler(dummyApigwEvent, dummyContext);
+    expect(res.statusCode).toEqual(400);
+    expect(JSON.parse(res.body).message).toBe('Empty request body');
+  });
+
+  it('should send a BAD_REQUEST response when the body isnt in JSON', async () => {
+    dummyApigwEvent.body = 'this is not json 1234';
+
+    const res = await handler(dummyApigwEvent, dummyContext);
+    expect(res.statusCode).toEqual(400);
+    expect(JSON.parse(res.body).message).toBe('Error parsing request body into JSON');
+  });
+
+  it('should send NOT_FOUND when delete testRecord service throws NoDeleteWarning', async () => {
+    moqDeleteTestResultSvc.setup(x => x(It.isAny())).throws(new NoDeleteWarning());
+    dummyApigwEvent.body = JSON.stringify({
+      retry_count: 12,
+      error_message: null,
+    });
+
+    const res = await handler(dummyApigwEvent, dummyContext);
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/src/functions/deleteTestResultRecord/framework/database/__tests__/query-builder.spec.ts
+++ b/src/functions/deleteTestResultRecord/framework/database/__tests__/query-builder.spec.ts
@@ -1,25 +1,8 @@
 import { deleteTestResultRecord } from '../query-builder';
 
 describe('deleteTestResultRecord query builder', () => {
-
-  let dummyRequestBody: any;
-
-  beforeEach(() => {
-    dummyRequestBody = {
-      retry_count: 15,
-      error_message: '500 Internal Server Error',
-    };
-  });
   it('should contain DELETE', () => {
-    const res = deleteTestResultRecord(dummyRequestBody);
+    const res = deleteTestResultRecord();
     expect(res).toMatch(/DELETE/);
-  });
-  it('should contain the correct retry count', () => {
-    const res = deleteTestResultRecord(dummyRequestBody);
-    expect(res).toMatch(/retry_count = retry_count \+ 15/);
-  });
-  it('should contain the correct error message', () => {
-    const res = deleteTestResultRecord(dummyRequestBody);
-    expect(res).toMatch(/error_message = '500 Internal Server Error'/);
   });
 });

--- a/src/functions/deleteTestResultRecord/framework/database/__tests__/query-builder.spec.ts
+++ b/src/functions/deleteTestResultRecord/framework/database/__tests__/query-builder.spec.ts
@@ -1,0 +1,25 @@
+import { deleteTestResultRecord } from '../query-builder';
+
+describe('deleteTestResultRecord query builder', () => {
+
+  let dummyRequestBody: any;
+
+  beforeEach(() => {
+    dummyRequestBody = {
+      retry_count: 15,
+      error_message: '500 Internal Server Error',
+    };
+  });
+  it('should contain DELETE', () => {
+    const res = deleteTestResultRecord(dummyRequestBody);
+    expect(res).toMatch(/DELETE/);
+  });
+  it('should contain the correct retry count', () => {
+    const res = deleteTestResultRecord(dummyRequestBody);
+    expect(res).toMatch(/retry_count = retry_count \+ 15/);
+  });
+  it('should contain the correct error message', () => {
+    const res = deleteTestResultRecord(dummyRequestBody);
+    expect(res).toMatch(/error_message = '500 Internal Server Error'/);
+  });
+});

--- a/src/functions/deleteTestResultRecord/framework/database/query-builder.ts
+++ b/src/functions/deleteTestResultRecord/framework/database/query-builder.ts
@@ -1,0 +1,19 @@
+import * as mysql from 'mysql2';
+
+// @ts-ignore
+export const deleteTestResultRecord = (body: any): string => {
+  let retryCount: number;
+  let errorMessage: string | null;
+
+  const template = `
+  DELETE FROM TEST_RESULT WHERE test_date <= DATE_ADD(NOW(), INTERVAL -2 YEAR)`;
+  retryCount = body.retry_count;
+  errorMessage = body.error_message;
+
+  const args = [
+    retryCount,
+    errorMessage,
+  ];
+
+  return mysql.format(template, args);
+};

--- a/src/functions/deleteTestResultRecord/framework/database/query-builder.ts
+++ b/src/functions/deleteTestResultRecord/framework/database/query-builder.ts
@@ -1,19 +1,10 @@
 import * as mysql from 'mysql2';
 
 // @ts-ignore
-export const deleteTestResultRecord = (body: any): string => {
-  let retryCount: number;
-  let errorMessage: string | null;
-
+export const deleteTestResultRecord = (): string => {
   const template = `
   DELETE FROM TEST_RESULT WHERE test_date <= DATE_ADD(NOW(), INTERVAL -2 YEAR)`;
-  retryCount = body.retry_count;
-  errorMessage = body.error_message;
-
-  const args = [
-    retryCount,
-    errorMessage,
-  ];
+  const args = [];
 
   return mysql.format(template, args);
 };

--- a/src/functions/deleteTestResultRecord/framework/handler.ts
+++ b/src/functions/deleteTestResultRecord/framework/handler.ts
@@ -1,56 +1,32 @@
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
-import { get } from 'lodash';
 import Response from '../../../common/application/api/Response';
 import createResponse from '../../../common/application/utils/createResponse';
 import { HttpStatus } from '../../../common/application/api/HttpStatus';
 import { bootstrapConfig } from '../../../common/framework/config/config';
-import { isNullOrBlank } from '../../../functions/postResult/framework/handler';
 import { deleteTestResult } from '../application/delete-testResult-service';
 
 import { error, warn, debug, bootstrapLogging } from '@dvsa/mes-microservice-common/application/utils/logger';
 import { NoDeleteWarning } from '../domain/NoDeleteWarning';
-import { SubmissionOutcome } from '../domain/SubmissionOutcome';
 
 export async function handler(event: APIGatewayProxyEvent, fnCtx: Context): Promise<Response> {
 
   bootstrapLogging('delete-test-history', event);
   await bootstrapConfig();
 
-  let body: SubmissionOutcome;
-
-  if (isNullOrBlank(event.body)) {
-    return createResponse({ message: 'Empty request body' }, HttpStatus.BAD_REQUEST);
-  }
-
   try {
-    body = JSON.parse(event.body);
-  } catch (err) {
-    error('Failure parsing request body', body, 'event body', event.body);
-    return createResponse({ message: 'Error parsing request body into JSON' }, HttpStatus.BAD_REQUEST);
-  }
-
-  try {
-    await deleteTestResult(body);
+    await deleteTestResult();
   } catch (err) {
     if (err instanceof NoDeleteWarning) {
-      warn('No Records Deleted Warning - ', ...enrichError(err, body));
+      warn('No Records Deleted Warning - ');
       return createResponse(
                 { message: `Failed to delete Test Result Records` },
                 HttpStatus.NOT_FOUND,
             );
     }
-    error('Error while deleting Test History - ' , ...enrichError(err, body));
+    error('Error while deleting Test History - ');
     return createResponse(
             // tslint:disable-next-line:max-line-length
             { message: `Error deleting Test History:` }, HttpStatus.INTERNAL_SERVER_ERROR);
   }
   return createResponse({}, HttpStatus.CREATED);
-}
-
-function enrichError(err: any, body: SubmissionOutcome) {
-  return {
-    ...err,
-    retryCount: get(body, 'retry_count'),
-    errorMessage: get(body, 'error_message'),
-  };
 }

--- a/src/functions/deleteTestResultRecord/framework/handler.ts
+++ b/src/functions/deleteTestResultRecord/framework/handler.ts
@@ -1,0 +1,56 @@
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { get } from 'lodash';
+import Response from '../../../common/application/api/Response';
+import createResponse from '../../../common/application/utils/createResponse';
+import { HttpStatus } from '../../../common/application/api/HttpStatus';
+import { bootstrapConfig } from '../../../common/framework/config/config';
+import { isNullOrBlank } from '../../../functions/postResult/framework/handler';
+import { deleteTestResult } from '../application/delete-testResult-service';
+
+import { error, warn, debug, bootstrapLogging } from '@dvsa/mes-microservice-common/application/utils/logger';
+import { NoDeleteWarning } from '../domain/NoDeleteWarning';
+import { SubmissionOutcome } from '../domain/SubmissionOutcome';
+
+export async function handler(event: APIGatewayProxyEvent, fnCtx: Context): Promise<Response> {
+
+  bootstrapLogging('delete-test-history', event);
+  await bootstrapConfig();
+
+  let body: SubmissionOutcome;
+
+  if (isNullOrBlank(event.body)) {
+    return createResponse({ message: 'Empty request body' }, HttpStatus.BAD_REQUEST);
+  }
+
+  try {
+    body = JSON.parse(event.body);
+  } catch (err) {
+    error('Failure parsing request body', body, 'event body', event.body);
+    return createResponse({ message: 'Error parsing request body into JSON' }, HttpStatus.BAD_REQUEST);
+  }
+
+  try {
+    await deleteTestResult(body);
+  } catch (err) {
+    if (err instanceof NoDeleteWarning) {
+      warn('No Records Deleted Warning - ', ...enrichError(err, body));
+      return createResponse(
+                { message: `Failed to delete Test Result Records` },
+                HttpStatus.NOT_FOUND,
+            );
+    }
+    error('Error while deleting Test History - ' , ...enrichError(err, body));
+    return createResponse(
+            // tslint:disable-next-line:max-line-length
+            { message: `Error deleting Test History:` }, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+  return createResponse({}, HttpStatus.CREATED);
+}
+
+function enrichError(err: any, body: SubmissionOutcome) {
+  return {
+    ...err,
+    retryCount: get(body, 'retry_count'),
+    errorMessage: get(body, 'error_message'),
+  };
+}


### PR DESCRIPTION
# Description and relevant Jira numbers

This adds an additional function to delete records from the TestResults table in the API database results schema that are greater than 2 years old in line with the Data Retention Policy requirements outlined in MES-3853

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA