### PR TITLE
fix: (mes-11266) limit manual intervention interface replacement

### DIFF
--- a/src/functions/retryProcessing/framework/database/__tests__/query-templates.spec.ts
+++ b/src/functions/retryProcessing/framework/database/__tests__/query-templates.spec.ts
@@ -1,0 +1,25 @@
+import { manualInterventionUploadQueueReplacementQuery } from '../query-templates';
+
+describe('QueryTemplates', () => {
+  describe('manualInterventionUploadQueueReplacementQuery', () => {
+    it('should select legacy interfaces for non-DSP tests', () => {
+      expect(manualInterventionUploadQueueReplacementQuery).toContain('tr.booking_reference IS NULL');
+      expect(manualInterventionUploadQueueReplacementQuery)
+        .toContain('it.interface_type_name IN (\'TARS\', \'NOTIFY\')');
+      expect(manualInterventionUploadQueueReplacementQuery)
+        .toContain('tr.autosave = false AND it.interface_type_name = \'RSIS\'');
+    });
+
+    it('should select DSP interfaces for tests with a booking reference', () => {
+      expect(manualInterventionUploadQueueReplacementQuery).toContain('tr.booking_reference IS NOT NULL');
+      expect(manualInterventionUploadQueueReplacementQuery)
+        .toContain('it.interface_type_name IN (\'DSP\', \'NOTIFY\')');
+      expect(manualInterventionUploadQueueReplacementQuery)
+        .toContain('tr.autosave = false AND it.interface_type_name = \'MI\'');
+    });
+
+    it('should not create replacement records by cross-joining all interface types', () => {
+      expect(manualInterventionUploadQueueReplacementQuery).not.toContain('FROM TEST_RESULT tr, INTERFACE_TYPE it');
+    });
+  });
+});

--- a/src/functions/retryProcessing/framework/database/query-templates.ts
+++ b/src/functions/retryProcessing/framework/database/query-templates.ts
@@ -123,14 +123,24 @@ export const manualInterventionUploadQueueReplacementQuery = `
       (SELECT id FROM PROCESSING_STATUS WHERE processing_status_name = 'PROCESSING') as upload_status,
       0 as retry_count,
       NULL as error_message
-  FROM TEST_RESULT tr, INTERFACE_TYPE it
+  FROM TEST_RESULT tr
+  JOIN INTERFACE_TYPE it
+    ON (
+      tr.booking_reference IS NULL
+      AND (
+        it.interface_type_name IN ('TARS', 'NOTIFY')
+        OR (tr.autosave = false AND it.interface_type_name = 'RSIS')
+      )
+    )
+    OR (
+      tr.booking_reference IS NOT NULL
+      AND (
+        it.interface_type_name IN ('DSP', 'NOTIFY')
+        OR (tr.autosave = false AND it.interface_type_name = 'MI')
+      )
+    )
   WHERE
     tr.result_status = (SELECT id FROM RESULT_STATUS WHERE result_status_name = 'PENDING')
-    AND (
-      (tr.autosave = true AND it.id != (SELECT id FROM INTERFACE_TYPE WHERE interface_type_name = 'RSIS'))
-      OR
-      (tr.autosave = false)
-    )
 ) ON DUPLICATE KEY UPDATE
 	UPLOAD_QUEUE.application_reference = UPLOAD_QUEUE.application_reference
 `;


### PR DESCRIPTION
## Summary

https://dvsa.atlassian.net/browse/MES-11266

- constrain manual intervention upload queue replacement to the expected interface set
- choose legacy TARS/NOTIFY/RSIS rows for non-DSP tests and DSP/NOTIFY/MI rows for booking-reference tests
- add a regression spec to ensure replacement no longer cross-joins every interface type

## Verification
- npm run compile-no-emit
- npm run lint
- npm run compile && npx jasmine build/src/functions/retryProcessing/framework/database/__tests__/query-templates.spec.js

Note: the push hook full `npm test` run was blocked by existing Joi schema validation failures: `TypeError: Util.isObject is not a function`. The new QueryTemplates specs passed during that run.